### PR TITLE
fix shell to draw error codes table properly

### DIFF
--- a/define/README.md
+++ b/define/README.md
@@ -2,5 +2,5 @@
 
 | Category | Http Status | Code | Info Message |
 ----|----|----|----
-| newBadRequest("invalid_parameter", "パラメータが不正です。" | newBadRequest("invalid_parameter", "パラメータが不正です。" | newBadRequest("invalid_parameter", "パラメータが不正です。" | newBadRequest(invalid_parameter, パラメータが不正です。 |
-| newInternalServerError("sytem_default", "エラーが発生しました。" | newInternalServerError("sytem_default", "エラーが発生しました。" | newInternalServerError("sytem_default", "エラーが発生しました。" | newInternalServerError(sytem_default, エラーが発生しました。 |
+| sample | BadRequest | invalid_parameter | パラメータが不正です。 |
+| sample | InternalServerError | sytem_default | エラーが発生しました。 |

--- a/define/create.sh
+++ b/define/create.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-lines=$(grep -o -e 'new[A-Z].*' ../define_*)
+lines=$(grep -o -e 'new[A-Z].*' ../define_* -H)
 
 out=$(cat << EOS
 # Error Codes


### PR DESCRIPTION
`-H`option なしの`grep -o -e 'new[A-Z].*' ../define_*`ではファイル名が表示されず、意図した挙動になっていなかったので修正しました。